### PR TITLE
Moved to 1-time parquet read only, future runs use .pkl instead.

### DIFF
--- a/BengaliDataset.py
+++ b/BengaliDataset.py
@@ -1,28 +1,32 @@
+import pandas as pd
 import torch
-from  torch.utils.data import Dataset
-import numpy as np
+from torch.utils.data import Dataset
 
 class BengaliDataset(Dataset):
+    
+    HEIGHT = 137
+    WIDTH = 236
 
-    def __init__(self, data, transform = None):
-        self.data = data
+    def __init__(self, dataframe, transform=None):
+        label_list = ['grapheme_root', 'vowel_diacritic', 'consonant_diacritic']
+        self.labels = dataframe[['grapheme_root', 'vowel_diacritic', 'consonant_diacritic']].copy(deep=True)
+        self.data = dataframe.copy(deep=False)
+        self.data.drop(columns=label_list, inplace=True)
         self.transform = transform
-        self.labels = self.data[['grapheme_root', 'vowel_diacritic', 'consonant_diacritic']].astype(np.int, errors='raise', copy=False)
+    
     def __len__(self):
         return len(self.data)
-
-    def __getitem__(self,idx):
-        if(torch.is_tensor(idx)):
+    
+    def __getitem__(self, idx):
+        if (torch.is_tensor(idx)):
             idx = idx.tolist()
+        
+        img = self.data.iloc[idx,:].to_numpy().reshape((-1, self.HEIGHT, self.WIDTH))
+        lbl = self.labels.iloc[idx,:].to_numpy()
 
-
-        a = self.data.iloc[idx,4:]
-        x = a.to_numpy()
-        x = x.astype('float').reshape(137,236)
-        y = self.labels.iloc[idx]
-        y = y.to_numpy()
-        y = y.reshape(-1,3)
-        sample = {'data':x, 'labels':y}
-        if(self.transform):
-            sample['data'] = self.transform(sample['data'])
-        return sample
+        if (self.transform):
+            img = self.transform(img)
+        return {
+            'data': img,
+            'labels': lbl,
+        }

--- a/testing.py
+++ b/testing.py
@@ -1,32 +1,39 @@
 import matplotlib.pyplot as plt
-from utils import getData, trainModel
+from utils import getData, trainModel, dsetToPickle
 from torch.utils.data import DataLoader
 from torchvision import transforms
 
-def testDataset():
-    train, test = getData('./dataset/', 'train.csv')
+def testDataset(need_pickle=False):
+    if (need_pickle):
+        pkl_path = dsetToPickle('./dataset/', 'train.csv')
+    else:
+        pkl_path = './dataset/full_data.pkl'
+    train, test = getData(pkl_path)
     print('Testing...')
-    print(train.data.iloc[0])
-    print(train[0])
-    print(train[[0,1]]['data'].shape)
-    print(train[[0,1]]['labels'])
-    print(train[[0,1]]['identifier'])
+    print("train.data:\n", train.data)
+    print("train[0]:\n", train[0])
     for i in range(5):
         plt.subplot(150 + i + 1)
-        sample = train[i]['data'][0][0]
-        plt.imshow(sample.astype(int),cmap='gray', vmin=0, vmax=255)
+        sample = train[i]['data'][0]
+        plt.imshow(sample.astype(int), cmap='gray', vmin=0, vmax=255)
     plt.show()
 
 
 
-def testTrainingLoop():
+def testTrainingLoop(need_pickle=False):
+    if (need_pickle):
+        pkl_path = dsetToPickle('./dataset/', 'train.csv')
+    else:
+        pkl_path = './dataset/full_data.pkl'
 
     main_transform = transforms.Compose([transforms.ToTensor()])
-    trainset, testset = getData('./dataset/', 'train.csv', train_transform = main_transform, test_transform = main_transform)
+    trainset, testset = getData(pkl_path, train_transform = main_transform, test_transform = main_transform)
     train_dataloader = DataLoader(trainset, batch_size = 64, shuffle = True, num_workers = 8)
     test_dataloader = DataLoader(testset, batch_size = 64, shuffle = True, num_workers = 8)
     trainModel(None, train_dataloader, test_dataloader)
 
 
-#testDataset()
-testTrainingLoop()
+if __name__ == '__main__':
+    # set this to true if you don't already have a pickle file
+    testDataset(need_pickle=False)
+    # testTrainingLoop(need_pickle=False)

--- a/utils.py
+++ b/utils.py
@@ -1,34 +1,62 @@
-import pyarrow.parquet as pq
+# import built-in modules
+import time
+from multiprocessing import Pool
+
+# import 3rd-party modules
 import pandas as pd
-from BengaliDataset import BengaliDataset as bd
+
+# import custom modules
+from BengaliDataset import BengaliDataset
 import train
-import numpy as np
 
+# def test_fn(filepath):
+#     return pd.read_parquet(filepath, engine='pyarrow')
 
-def getData(root_dir, csvfile, train_transform=None, test_transform=None):
-
+def dsetToPickle(root_dir, csvfile):
+    """Converts the parquet files to pickle format for faster io"""
     base_str = 'train_image_data_'
-    filetype = '.parquet'
-    labels = pd.read_csv(root_dir + csvfile)
-    data1 = pq.read_pandas(root_dir + base_str + '0' + filetype).to_pandas()
-    print('First parquet read')
-    data2 = pq.read_pandas(root_dir + base_str + '1' + filetype).to_pandas()
-    print('Second parquet read')
-    data3 = pq.read_pandas(root_dir + base_str + '2' + filetype).to_pandas()
-    print('Third parquet read')
-    data4 = pq.read_pandas(root_dir + base_str + '3' + filetype).to_pandas()
-    print('Fourth parquet read')
-    data = pd.concat([data1, data2, data3, data4])
-    print('All data loaded')
+    labels = pd.read_csv(root_dir + csvfile).set_index('image_id', drop=True)
+    filepaths = []
+    for i in range(4):
+        filepaths.append(root_dir + base_str + str(i) + '.parquet')
+    start_time = time.time()
+    print("Reading parquet files...")
+    # with Pool(processes=4) as pool:
+    #     data = pool.map(test_fn, filepaths)
+    # print(data)
+    data = []
+    for i in range(4):
+        data.append(pd.read_parquet(filepaths[i], engine='pyarrow').set_index('image_id', drop=True))
+        print("Loaded parquet file " + str(i) + "...")
+    data = pd.concat(data, copy=False)
+    print("Parquet loading completed. Elapsed: %d seconds" % (time.time() - start_time))
+
+    # insert labels to the front of the dataframe
+    labels = labels.iloc[:len(data)]
     data.insert(0, 'grapheme_root', labels['grapheme_root'])
     data.insert(1, 'vowel_diacritic', labels['vowel_diacritic'])
     data.insert(2, 'consonant_diacritic', labels['consonant_diacritic'])
+    del(labels) # probably not required, but clears up some memory
 
-    del(labels)
-    del(data1, data2, data3, data4)
-    data.astype(np.int8, errors='ignore', copy=False)
-    train = bd(data.iloc[:160672], transform=train_transform)
-    test = bd(data.iloc[160672:], transform=test_transform)
+    # shuffle
+    data = data.sample(frac=1)
+
+    # save to pickle file
+    pkl_path = root_dir + "full_data.pkl"
+    data.to_pickle(pkl_path)
+    del(data)
+    return pkl_path
+
+def getData(pickle_path, split=0.8, train_transform=None, test_transform=None):
+    start_time = time.time()
+    print("Reading pickle from " + pickle_path + "...")
+    data = pd.read_pickle(pickle_path)
+    print("Pickle loading completed. Elapsed: %d seconds" % (time.time() - start_time))
+    split_index = int(split * len(data))
+
+    # create the BengaliDataset objects
+    train = BengaliDataset(data.iloc[:split_index], transform=train_transform)
+    test = BengaliDataset(data.iloc[split_index:], transform=test_transform)
     return train, test
 
 


### PR DESCRIPTION
Shuffling works, but still spikes at momentary high memory. I think I've fixed all merge conflicts, and I've tested by printing out the dataset and with `testDataset()`.

I haven't tested actually running a training epoch, so hopefully we don't have any errors... but we might get some type errors if pytorch doesn't like the current implementation with uint8 (which was default, actually, this time).