### PR TITLE
Hotfix for getitem to return image of shape (height, width)

### DIFF
--- a/BengaliDataset.py
+++ b/BengaliDataset.py
@@ -21,7 +21,7 @@ class BengaliDataset(Dataset):
         if (torch.is_tensor(idx)):
             idx = idx.tolist()
         
-        img = self.data.iloc[idx,:].to_numpy().reshape((-1, self.HEIGHT, self.WIDTH))
+        img = self.data.iloc[idx,:].to_numpy().reshape((self.HEIGHT, self.WIDTH))
         lbl = self.labels.iloc[idx,:].to_numpy()
 
         if (self.transform):


### PR DESCRIPTION
CustomModel1 expects images returned from `__getitem__` to be of the shape (height, width) instead of (1, height, width).

Changed the BengaliDataset class to fit that.